### PR TITLE
Expose noCurve attribute

### DIFF
--- a/swipeable-card.html
+++ b/swipeable-card.html
@@ -18,7 +18,7 @@ A card that can be swiped to the left or right to move it out of the way.
 
 <link rel="stylesheet" href="swipeable-card.css" shim-shadowdom>
 
-<polymer-element name="swipeable-card" attributes="disableSwipe swiped">
+<polymer-element name="swipeable-card" attributes="disableSwipe swiped noCurve">
     
 <script>
 


### PR DESCRIPTION
noCurve used to be exposed back in ye olde times of polymer-ui-card, but it seems to have been forgotten when creating swipeable-card. Re-adding because I'm confident there will be those who want to disable the swipe animation's curve ( I know I do ;) )
